### PR TITLE
allow making bastions highly available

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   prerequisites:
@@ -161,7 +161,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   publish:
@@ -202,7 +202,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   publish_sdk:
@@ -280,7 +280,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   test:
@@ -365,7 +365,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
 name: main

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   prerequisites:
@@ -162,7 +162,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   publish:
@@ -203,7 +203,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   publish_sdk:
@@ -281,7 +281,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   test:
@@ -366,7 +366,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
 name: prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   prerequisites:
@@ -161,7 +161,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   publish:
@@ -202,7 +202,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   publish_sdk:
@@ -280,7 +280,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   test:
@@ -365,7 +365,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
 name: release

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   comment-notification:
@@ -187,7 +187,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
   test:
@@ -276,7 +276,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 16.x
+        - 18.x
         pythonversion:
         - "3.7"
 name: run-acceptance-tests

--- a/provider/pkg/provider/aws/bastion.go
+++ b/provider/pkg/provider/aws/bastion.go
@@ -25,12 +25,13 @@ var (
 
 // The set of arguments for creating a Bastion component resource.
 type BastionArgs struct {
-	VpcID         pulumi.StringInput      `pulumi:"vpcId"`
-	SubnetIds     pulumi.StringArrayInput `pulumi:"subnetIds"`
-	TailscaleTags pulumi.StringArrayInput `pulumi:"tailscaleTags"`
-	Route         pulumi.StringInput      `pulumi:"route"`
-	Region        pulumi.StringInput      `pulumi:"region"`
-	InstanceType  pulumi.StringInput      `pulumi:"instanceType"`
+	VpcID            pulumi.StringInput      `pulumi:"vpcId"`
+	SubnetIds        pulumi.StringArrayInput `pulumi:"subnetIds"`
+	TailscaleTags    pulumi.StringArrayInput `pulumi:"tailscaleTags"`
+	Route            pulumi.StringInput      `pulumi:"route"`
+	Region           pulumi.StringInput      `pulumi:"region"`
+	InstanceType     pulumi.StringInput      `pulumi:"instanceType"`
+	HighAvailability bool                    `pulumi:"highAvailability"`
 }
 
 type UserDataArgs struct {
@@ -291,10 +292,18 @@ func NewBastion(ctx *pulumi.Context,
 		return nil, fmt.Errorf("error creating launch configuration: %v", err)
 	}
 
+	var size int
+
+	if args.HighAvailability {
+		size = 2
+	} else {
+		size = 1
+	}
+
 	asg, err := autoscaling.NewGroup(ctx, name, &autoscaling.GroupArgs{
 		LaunchConfiguration:    launchConfiguration.ID(),
-		MaxSize:                pulumi.Int(1),
-		MinSize:                pulumi.Int(1),
+		MaxSize:                pulumi.Int(size),
+		MinSize:                pulumi.Int(size),
 		HealthCheckType:        pulumi.String("EC2"),
 		HealthCheckGracePeriod: pulumi.Int(30),
 		VpcZoneIdentifiers:     args.SubnetIds,

--- a/provider/pkg/provider/azure/bastion.go
+++ b/provider/pkg/provider/azure/bastion.go
@@ -27,6 +27,7 @@ type BastionArgs struct {
 	Route             pulumi.StringInput      `pulumi:"route"`
 	InstanceSku       pulumi.StringInput      `pulumi:"instanceSku"`
 	TailscaleTags     pulumi.StringArrayInput `pulumi:"tailscaleTags"`
+	HighAvailability  bool                    `pulumi:"highAvailability"`
 }
 
 type UserDataArgs struct {
@@ -113,12 +114,20 @@ func NewBastion(ctx *pulumi.Context,
 		return nil, err
 	}
 
+	var size int
+
+	if args.HighAvailability {
+		size = 2
+	} else {
+		size = 1
+	}
+
 	scaleset, err := compute.NewLinuxVirtualMachineScaleSet(ctx, name, &compute.LinuxVirtualMachineScaleSetArgs{
 		ResourceGroupName: args.ResourceGroupName,
 		Location:          args.Location,
 		UpgradeMode:       pulumi.String("Manual"),
 		Sku:               sku,
-		Instances:         pulumi.Int(1),
+		Instances:         pulumi.Int(size),
 		SourceImageReference: &compute.LinuxVirtualMachineScaleSetSourceImageReferenceArgs{
 			Publisher: pulumi.String("Canonical"),
 			Offer:     pulumi.String("0001-com-ubuntu-server-focal"),

--- a/provider/pkg/provider/kubernetes/bastion.go
+++ b/provider/pkg/provider/kubernetes/bastion.go
@@ -14,10 +14,11 @@ import (
 
 // The set of arguments for creating a Bastion component resource.
 type BastionArgs struct {
-	CreateNamespace bool                    `pulumi:"createNamespace"`
-	Namespace       *corev1.Namespace       `pulumi:"namespace"`
-	Routes          pulumi.StringArrayInput `pulumi:"routes"`
-	TailscaleTags   pulumi.StringArrayInput `pulumi:"tailscaleTags"`
+	CreateNamespace  bool                    `pulumi:"createNamespace"`
+	Namespace        *corev1.Namespace       `pulumi:"namespace"`
+	Routes           pulumi.StringArrayInput `pulumi:"routes"`
+	TailscaleTags    pulumi.StringArrayInput `pulumi:"tailscaleTags"`
+	HighAvailability bool                    `pulumi:"highAvailability"`
 }
 
 // The Bastion component resource.
@@ -149,12 +150,20 @@ func NewBastion(ctx *pulumi.Context,
 		},
 	).(pulumi.StringOutput)
 
+	var size int
+
+	if args.HighAvailability {
+		size = 2
+	} else {
+		size = 1
+	}
+
 	deployment, err := appsv1.NewDeployment(ctx, name, &appsv1.DeploymentArgs{
 		Metadata: &metav1.ObjectMetaArgs{
 			Namespace: namespace.Metadata.Name(),
 		},
 		Spec: &appsv1.DeploymentSpecArgs{
-			Replicas: pulumi.Int(1),
+			Replicas: pulumi.Int(size),
 			Selector: &metav1.LabelSelectorArgs{
 				MatchLabels: pulumi.StringMap{
 					"name":        pulumi.String(name),

--- a/schema.yaml
+++ b/schema.yaml
@@ -25,12 +25,17 @@ resources:
       instanceSku:
         type: string
         description: "The Azure instance SKU to use for the bastion."
+      highAvailability:
+        type: boolean
+        description: "Whether the bastion should be highly available."
+        default: false
       tailscaleTags:
         type: array
         items:
           type: string
         description: "The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL."
     requiredInputs:
+      - highAvailability
       - resourceGroupName
       - subnetId
       - route
@@ -49,6 +54,10 @@ resources:
   tailscale-bastion:aws:Bastion:
     isComponent: true
     inputProperties:
+      highAvailability:
+        type: boolean
+        description: "Whether the bastion should be highly available."
+        default: false
       vpcId:
         type: string
         description: "The VPC the Bastion should be created in."
@@ -72,6 +81,7 @@ resources:
         type: string
         description: "The EC2 instance type to use for the bastion."
     requiredInputs:
+      - highAvailability
       - vpcId
       - subnetIds
       - route
@@ -90,6 +100,10 @@ resources:
   tailscale-bastion:kubernetes:Bastion:
     isComponent: true
     inputProperties:
+      highAvailability:
+        type: boolean
+        description: "Whether the bastion should be highly available."
+        default: false
       tailscaleTags:
         type: array
         items:
@@ -108,6 +122,7 @@ resources:
           type: string
         description: "The routes to advertise to tailscale. This is likely the Pod and Service CIDR."
     requiredInputs:
+      - highAvailability
       - createNamespace
       - routes
       - tailscaleTags

--- a/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
+++ b/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
@@ -55,6 +55,12 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
     public sealed class BastionArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// Whether the bastion should be highly available.
+        /// </summary>
+        [Input("highAvailability", required: true)]
+        public Input<bool> HighAvailability { get; set; } = null!;
+
+        /// <summary>
         /// The EC2 instance type to use for the bastion.
         /// </summary>
         [Input("instanceType")]
@@ -104,6 +110,7 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
 
         public BastionArgs()
         {
+            HighAvailability = false;
         }
         public static new BastionArgs Empty => new BastionArgs();
     }

--- a/sdk/dotnet/TailscaleBastion/Azure/Bastion.cs
+++ b/sdk/dotnet/TailscaleBastion/Azure/Bastion.cs
@@ -55,6 +55,12 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Azure
     public sealed class BastionArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// Whether the bastion should be highly available.
+        /// </summary>
+        [Input("highAvailability", required: true)]
+        public Input<bool> HighAvailability { get; set; } = null!;
+
+        /// <summary>
         /// The Azure instance SKU to use for the bastion.
         /// </summary>
         [Input("instanceSku")]
@@ -98,6 +104,7 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Azure
 
         public BastionArgs()
         {
+            HighAvailability = false;
         }
         public static new BastionArgs Empty => new BastionArgs();
     }

--- a/sdk/dotnet/TailscaleBastion/Kubernetes/Bastion.cs
+++ b/sdk/dotnet/TailscaleBastion/Kubernetes/Bastion.cs
@@ -55,6 +55,12 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Kubernetes
         public bool CreateNamespace { get; set; }
 
         /// <summary>
+        /// Whether the bastion should be highly available.
+        /// </summary>
+        [Input("highAvailability", required: true)]
+        public Input<bool> HighAvailability { get; set; } = null!;
+
+        /// <summary>
         /// The bucket resource.
         /// </summary>
         [Input("namespace")]
@@ -86,6 +92,7 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Kubernetes
 
         public BastionArgs()
         {
+            HighAvailability = false;
         }
         public static new BastionArgs Empty => new BastionArgs();
     }

--- a/sdk/go/bastion/aws/bastion.go
+++ b/sdk/go/bastion/aws/bastion.go
@@ -44,6 +44,9 @@ func NewBastion(ctx *pulumi.Context,
 	if args.VpcId == nil {
 		return nil, errors.New("invalid value for required argument 'VpcId'")
 	}
+	if args.HighAvailability == nil {
+		args.HighAvailability = pulumi.Bool(false)
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Bastion
 	err := ctx.RegisterRemoteComponentResource("tailscale-bastion:aws:Bastion", name, args, &resource, opts...)
@@ -54,6 +57,8 @@ func NewBastion(ctx *pulumi.Context,
 }
 
 type bastionArgs struct {
+	// Whether the bastion should be highly available.
+	HighAvailability bool `pulumi:"highAvailability"`
 	// The EC2 instance type to use for the bastion.
 	InstanceType *string `pulumi:"instanceType"`
 	// The AWS region you're using.
@@ -70,6 +75,8 @@ type bastionArgs struct {
 
 // The set of arguments for constructing a Bastion resource.
 type BastionArgs struct {
+	// Whether the bastion should be highly available.
+	HighAvailability pulumi.BoolInput
 	// The EC2 instance type to use for the bastion.
 	InstanceType pulumi.StringPtrInput
 	// The AWS region you're using.

--- a/sdk/go/bastion/azure/bastion.go
+++ b/sdk/go/bastion/azure/bastion.go
@@ -44,6 +44,9 @@ func NewBastion(ctx *pulumi.Context,
 	if args.TailscaleTags == nil {
 		return nil, errors.New("invalid value for required argument 'TailscaleTags'")
 	}
+	if args.HighAvailability == nil {
+		args.HighAvailability = pulumi.Bool(false)
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Bastion
 	err := ctx.RegisterRemoteComponentResource("tailscale-bastion:azure:Bastion", name, args, &resource, opts...)
@@ -54,6 +57,8 @@ func NewBastion(ctx *pulumi.Context,
 }
 
 type bastionArgs struct {
+	// Whether the bastion should be highly available.
+	HighAvailability bool `pulumi:"highAvailability"`
 	// The Azure instance SKU to use for the bastion.
 	InstanceSku *string `pulumi:"instanceSku"`
 	// The Azure region you're using.
@@ -70,6 +75,8 @@ type bastionArgs struct {
 
 // The set of arguments for constructing a Bastion resource.
 type BastionArgs struct {
+	// Whether the bastion should be highly available.
+	HighAvailability pulumi.BoolInput
 	// The Azure instance SKU to use for the bastion.
 	InstanceSku pulumi.StringPtrInput
 	// The Azure region you're using.

--- a/sdk/go/bastion/kubernetes/bastion.go
+++ b/sdk/go/bastion/kubernetes/bastion.go
@@ -34,6 +34,9 @@ func NewBastion(ctx *pulumi.Context,
 	if args.TailscaleTags == nil {
 		return nil, errors.New("invalid value for required argument 'TailscaleTags'")
 	}
+	if args.HighAvailability == nil {
+		args.HighAvailability = pulumi.Bool(false)
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Bastion
 	err := ctx.RegisterRemoteComponentResource("tailscale-bastion:kubernetes:Bastion", name, args, &resource, opts...)
@@ -46,6 +49,8 @@ func NewBastion(ctx *pulumi.Context,
 type bastionArgs struct {
 	// Whether we should create a new namespace.
 	CreateNamespace bool `pulumi:"createNamespace"`
+	// Whether the bastion should be highly available.
+	HighAvailability bool `pulumi:"highAvailability"`
 	// The bucket resource.
 	Namespace *corev1.Namespace `pulumi:"namespace"`
 	// The routes to advertise to tailscale. This is likely the Pod and Service CIDR.
@@ -58,6 +63,8 @@ type bastionArgs struct {
 type BastionArgs struct {
 	// Whether we should create a new namespace.
 	CreateNamespace bool
+	// Whether the bastion should be highly available.
+	HighAvailability pulumi.BoolInput
 	// The bucket resource.
 	Namespace corev1.NamespaceInput
 	// The routes to advertise to tailscale. This is likely the Pod and Service CIDR.

--- a/sdk/nodejs/aws/bastion.ts
+++ b/sdk/nodejs/aws/bastion.ts
@@ -39,6 +39,9 @@ export class Bastion extends pulumi.ComponentResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.highAvailability === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'highAvailability'");
+            }
             if ((!args || args.region === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'region'");
             }
@@ -54,6 +57,7 @@ export class Bastion extends pulumi.ComponentResource {
             if ((!args || args.vpcId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'vpcId'");
             }
+            resourceInputs["highAvailability"] = (args ? args.highAvailability : undefined) ?? false;
             resourceInputs["instanceType"] = args ? args.instanceType : undefined;
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["route"] = args ? args.route : undefined;
@@ -75,6 +79,10 @@ export class Bastion extends pulumi.ComponentResource {
  * The set of arguments for constructing a Bastion resource.
  */
 export interface BastionArgs {
+    /**
+     * Whether the bastion should be highly available.
+     */
+    highAvailability: pulumi.Input<boolean>;
     /**
      * The EC2 instance type to use for the bastion.
      */

--- a/sdk/nodejs/azure/bastion.ts
+++ b/sdk/nodejs/azure/bastion.ts
@@ -39,6 +39,9 @@ export class Bastion extends pulumi.ComponentResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.highAvailability === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'highAvailability'");
+            }
             if ((!args || args.location === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'location'");
             }
@@ -54,6 +57,7 @@ export class Bastion extends pulumi.ComponentResource {
             if ((!args || args.tailscaleTags === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'tailscaleTags'");
             }
+            resourceInputs["highAvailability"] = (args ? args.highAvailability : undefined) ?? false;
             resourceInputs["instanceSku"] = args ? args.instanceSku : undefined;
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["resourceGroupName"] = args ? args.resourceGroupName : undefined;
@@ -75,6 +79,10 @@ export class Bastion extends pulumi.ComponentResource {
  * The set of arguments for constructing a Bastion resource.
  */
 export interface BastionArgs {
+    /**
+     * Whether the bastion should be highly available.
+     */
+    highAvailability: pulumi.Input<boolean>;
     /**
      * The Azure instance SKU to use for the bastion.
      */

--- a/sdk/nodejs/kubernetes/bastion.ts
+++ b/sdk/nodejs/kubernetes/bastion.ts
@@ -40,6 +40,9 @@ export class Bastion extends pulumi.ComponentResource {
             if ((!args || args.createNamespace === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'createNamespace'");
             }
+            if ((!args || args.highAvailability === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'highAvailability'");
+            }
             if ((!args || args.routes === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'routes'");
             }
@@ -47,6 +50,7 @@ export class Bastion extends pulumi.ComponentResource {
                 throw new Error("Missing required property 'tailscaleTags'");
             }
             resourceInputs["createNamespace"] = args ? args.createNamespace : undefined;
+            resourceInputs["highAvailability"] = (args ? args.highAvailability : undefined) ?? false;
             resourceInputs["namespace"] = args ? args.namespace : undefined;
             resourceInputs["routes"] = args ? args.routes : undefined;
             resourceInputs["tailscaleTags"] = args ? args.tailscaleTags : undefined;
@@ -67,6 +71,10 @@ export interface BastionArgs {
      * Whether we should create a new namespace.
      */
     createNamespace: boolean;
+    /**
+     * Whether the bastion should be highly available.
+     */
+    highAvailability: pulumi.Input<boolean>;
     /**
      * The bucket resource.
      */

--- a/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
+++ b/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
@@ -14,6 +14,7 @@ __all__ = ['BastionArgs', 'Bastion']
 @pulumi.input_type
 class BastionArgs:
     def __init__(__self__, *,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  region: pulumi.Input[str],
                  route: pulumi.Input[str],
                  subnet_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
@@ -22,6 +23,7 @@ class BastionArgs:
                  instance_type: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Bastion resource.
+        :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input[str] region: The AWS region you're using.
         :param pulumi.Input[str] route: The route you'd like to advertise via tailscale.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The subnet Ids to launch instances in.
@@ -29,6 +31,9 @@ class BastionArgs:
         :param pulumi.Input[str] vpc_id: The VPC the Bastion should be created in.
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
         """
+        if high_availability is None:
+            high_availability = False
+        pulumi.set(__self__, "high_availability", high_availability)
         pulumi.set(__self__, "region", region)
         pulumi.set(__self__, "route", route)
         pulumi.set(__self__, "subnet_ids", subnet_ids)
@@ -36,6 +41,18 @@ class BastionArgs:
         pulumi.set(__self__, "vpc_id", vpc_id)
         if instance_type is not None:
             pulumi.set(__self__, "instance_type", instance_type)
+
+    @property
+    @pulumi.getter(name="highAvailability")
+    def high_availability(self) -> pulumi.Input[bool]:
+        """
+        Whether the bastion should be highly available.
+        """
+        return pulumi.get(self, "high_availability")
+
+    @high_availability.setter
+    def high_availability(self, value: pulumi.Input[bool]):
+        pulumi.set(self, "high_availability", value)
 
     @property
     @pulumi.getter
@@ -115,6 +132,7 @@ class Bastion(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  route: Optional[pulumi.Input[str]] = None,
@@ -126,6 +144,7 @@ class Bastion(pulumi.ComponentResource):
         Create a Bastion resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
         :param pulumi.Input[str] region: The AWS region you're using.
         :param pulumi.Input[str] route: The route you'd like to advertise via tailscale.
@@ -156,6 +175,7 @@ class Bastion(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  route: Optional[pulumi.Input[str]] = None,
@@ -173,6 +193,11 @@ class Bastion(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = BastionArgs.__new__(BastionArgs)
 
+            if high_availability is None:
+                high_availability = False
+            if high_availability is None and not opts.urn:
+                raise TypeError("Missing required property 'high_availability'")
+            __props__.__dict__["high_availability"] = high_availability
             __props__.__dict__["instance_type"] = instance_type
             if region is None and not opts.urn:
                 raise TypeError("Missing required property 'region'")

--- a/sdk/python/lbrlabs_pulumi_tailscalebastion/azure/bastion.py
+++ b/sdk/python/lbrlabs_pulumi_tailscalebastion/azure/bastion.py
@@ -14,6 +14,7 @@ __all__ = ['BastionArgs', 'Bastion']
 @pulumi.input_type
 class BastionArgs:
     def __init__(__self__, *,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  location: pulumi.Input[str],
                  resource_group_name: pulumi.Input[str],
                  route: pulumi.Input[str],
@@ -22,6 +23,7 @@ class BastionArgs:
                  instance_sku: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Bastion resource.
+        :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input[str] location: The Azure region you're using.
         :param pulumi.Input[str] resource_group_name: The Azure resource group to create the bastion in.
         :param pulumi.Input[str] route: The route you'd like to advertise via tailscale.
@@ -29,6 +31,9 @@ class BastionArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tailscale_tags: The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
         :param pulumi.Input[str] instance_sku: The Azure instance SKU to use for the bastion.
         """
+        if high_availability is None:
+            high_availability = False
+        pulumi.set(__self__, "high_availability", high_availability)
         pulumi.set(__self__, "location", location)
         pulumi.set(__self__, "resource_group_name", resource_group_name)
         pulumi.set(__self__, "route", route)
@@ -36,6 +41,18 @@ class BastionArgs:
         pulumi.set(__self__, "tailscale_tags", tailscale_tags)
         if instance_sku is not None:
             pulumi.set(__self__, "instance_sku", instance_sku)
+
+    @property
+    @pulumi.getter(name="highAvailability")
+    def high_availability(self) -> pulumi.Input[bool]:
+        """
+        Whether the bastion should be highly available.
+        """
+        return pulumi.get(self, "high_availability")
+
+    @high_availability.setter
+    def high_availability(self, value: pulumi.Input[bool]):
+        pulumi.set(self, "high_availability", value)
 
     @property
     @pulumi.getter
@@ -115,6 +132,7 @@ class Bastion(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  instance_sku: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  resource_group_name: Optional[pulumi.Input[str]] = None,
@@ -126,6 +144,7 @@ class Bastion(pulumi.ComponentResource):
         Create a Bastion resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input[str] instance_sku: The Azure instance SKU to use for the bastion.
         :param pulumi.Input[str] location: The Azure region you're using.
         :param pulumi.Input[str] resource_group_name: The Azure resource group to create the bastion in.
@@ -156,6 +175,7 @@ class Bastion(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  instance_sku: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  resource_group_name: Optional[pulumi.Input[str]] = None,
@@ -173,6 +193,11 @@ class Bastion(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = BastionArgs.__new__(BastionArgs)
 
+            if high_availability is None:
+                high_availability = False
+            if high_availability is None and not opts.urn:
+                raise TypeError("Missing required property 'high_availability'")
+            __props__.__dict__["high_availability"] = high_availability
             __props__.__dict__["instance_sku"] = instance_sku
             if location is None and not opts.urn:
                 raise TypeError("Missing required property 'location'")

--- a/sdk/python/lbrlabs_pulumi_tailscalebastion/kubernetes/bastion.py
+++ b/sdk/python/lbrlabs_pulumi_tailscalebastion/kubernetes/bastion.py
@@ -16,17 +16,22 @@ __all__ = ['BastionArgs', 'Bastion']
 class BastionArgs:
     def __init__(__self__, *,
                  create_namespace: bool,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  routes: pulumi.Input[Sequence[pulumi.Input[str]]],
                  tailscale_tags: pulumi.Input[Sequence[pulumi.Input[str]]],
                  namespace: Optional[pulumi.Input['pulumi_kubernetes.core.v1.Namespace']] = None):
         """
         The set of arguments for constructing a Bastion resource.
         :param bool create_namespace: Whether we should create a new namespace.
+        :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] routes: The routes to advertise to tailscale. This is likely the Pod and Service CIDR.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tailscale_tags: The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
         :param pulumi.Input['pulumi_kubernetes.core.v1.Namespace'] namespace: The bucket resource.
         """
         pulumi.set(__self__, "create_namespace", create_namespace)
+        if high_availability is None:
+            high_availability = False
+        pulumi.set(__self__, "high_availability", high_availability)
         pulumi.set(__self__, "routes", routes)
         pulumi.set(__self__, "tailscale_tags", tailscale_tags)
         if namespace is not None:
@@ -43,6 +48,18 @@ class BastionArgs:
     @create_namespace.setter
     def create_namespace(self, value: bool):
         pulumi.set(self, "create_namespace", value)
+
+    @property
+    @pulumi.getter(name="highAvailability")
+    def high_availability(self) -> pulumi.Input[bool]:
+        """
+        Whether the bastion should be highly available.
+        """
+        return pulumi.get(self, "high_availability")
+
+    @high_availability.setter
+    def high_availability(self, value: pulumi.Input[bool]):
+        pulumi.set(self, "high_availability", value)
 
     @property
     @pulumi.getter
@@ -87,6 +104,7 @@ class Bastion(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  create_namespace: Optional[bool] = None,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  namespace: Optional[pulumi.Input['pulumi_kubernetes.core.v1.Namespace']] = None,
                  routes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tailscale_tags: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -96,6 +114,7 @@ class Bastion(pulumi.ComponentResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param bool create_namespace: Whether we should create a new namespace.
+        :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input['pulumi_kubernetes.core.v1.Namespace'] namespace: The bucket resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] routes: The routes to advertise to tailscale. This is likely the Pod and Service CIDR.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tailscale_tags: The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
@@ -124,6 +143,7 @@ class Bastion(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  create_namespace: Optional[bool] = None,
+                 high_availability: Optional[pulumi.Input[bool]] = None,
                  namespace: Optional[pulumi.Input['pulumi_kubernetes.core.v1.Namespace']] = None,
                  routes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tailscale_tags: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -141,6 +161,11 @@ class Bastion(pulumi.ComponentResource):
             if create_namespace is None and not opts.urn:
                 raise TypeError("Missing required property 'create_namespace'")
             __props__.__dict__["create_namespace"] = create_namespace
+            if high_availability is None:
+                high_availability = False
+            if high_availability is None and not opts.urn:
+                raise TypeError("Missing required property 'high_availability'")
+            __props__.__dict__["high_availability"] = high_availability
             __props__.__dict__["namespace"] = namespace
             if routes is None and not opts.urn:
                 raise TypeError("Missing required property 'routes'")


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 81c6c35073bcc9c0e8ac9df5a9f23cc256549542.  | 
|--------|--------|

### Summary:
This PR adds support for high availability of bastions across `aws`, `azure`, and `kubernetes` providers, updates the auto-scaling and deployment logic, updates the `schema.yaml` and SDKs to include the `highAvailability` field, and updates the Node.js version used in the GitHub workflows from 16.x to 18.x.

**Key points**:
- Added `HighAvailability` field to `BastionArgs` struct in `aws`, `azure`, and `kubernetes` providers.
- Updated auto-scaling and deployment logic to create 2 instances/replicas if `HighAvailability` is `true`.
- Updated `schema.yaml` to include `highAvailability` in the schema of the bastion resources.
- Updated SDKs (`go`, `dotnet`, `python`, `nodejs`) to include `highAvailability` in the bastion resources.
- Updated Node.js version from 16.x to 18.x in GitHub workflows.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
<!--
ELLIPSIS_HIDDEN
-->
