### PR TITLE
allow tailscale SSH

### DIFF
--- a/provider/pkg/provider/aws/bastion.go
+++ b/provider/pkg/provider/aws/bastion.go
@@ -32,6 +32,7 @@ type BastionArgs struct {
 	Region           pulumi.StringInput      `pulumi:"region"`
 	InstanceType     pulumi.StringInput      `pulumi:"instanceType"`
 	HighAvailability bool                    `pulumi:"highAvailability"`
+	EnableSSH        bool                    `pulumi:"enableSSH"`
 }
 
 type UserDataArgs struct {
@@ -39,6 +40,7 @@ type UserDataArgs struct {
 	Route         string
 	Region        string
 	TailscaleTags []string
+	EnableSSH     bool
 }
 
 // Join the tags into a CSV
@@ -232,13 +234,14 @@ func NewBastion(ctx *pulumi.Context,
 		MostRecent: pulumi.BoolPtr(true),
 	}, pulumi.Parent(component))
 
-	data := pulumi.All(tailnetKeySsmParameter.Name, args.Route, args.Region, args.TailscaleTags).ApplyT(
+	data := pulumi.All(tailnetKeySsmParameter.Name, args.Route, args.Region, args.TailscaleTags, args.EnableSSH).ApplyT(
 		func(args []interface{}) (string, error) {
 			d := UserDataArgs{
 				ParameterName: args[0].(string),
 				Route:         args[1].(string),
 				Region:        args[2].(string),
 				TailscaleTags: args[3].([]string),
+				EnableSSH:     args[4].(bool),
 			}
 
 			var userDataBytes bytes.Buffer

--- a/provider/pkg/provider/aws/userdata.tmpl
+++ b/provider/pkg/provider/aws/userdata.tmpl
@@ -18,4 +18,4 @@ sudo yum-config-manager --add-repo https://pkgs.tailscale.com/stable/amazon-linu
 sudo yum install tailscale -y
 sudo systemctl enable --now tailscaled
 sleep 10
-sudo tailscale up --advertise-tags=tag:bastion --advertise-routes="{{ .Route }}" --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes
+sudo tailscale up ssh="{{ .EnableSSH }} --advertise-tags=tag:bastion --advertise-routes="{{ .Route }}" --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes

--- a/provider/pkg/provider/azure/bastion.go
+++ b/provider/pkg/provider/azure/bastion.go
@@ -28,12 +28,14 @@ type BastionArgs struct {
 	InstanceSku       pulumi.StringInput      `pulumi:"instanceSku"`
 	TailscaleTags     pulumi.StringArrayInput `pulumi:"tailscaleTags"`
 	HighAvailability  bool                    `pulumi:"highAvailability"`
+	EnableSSH         bool                    `pulumi:"enableSSH"`
 }
 
 type UserDataArgs struct {
 	AuthKey       string
 	Route         string
 	TailscaleTags []string
+	EnableSSH     bool
 }
 
 // Join the tags into a CSV
@@ -74,12 +76,13 @@ func NewBastion(ctx *pulumi.Context,
 		return nil, fmt.Errorf("error creating tailnet key: %v", err)
 	}
 
-	data := pulumi.All(tailnetKey.Key, args.Route, args.TailscaleTags).ApplyT(
+	data := pulumi.All(tailnetKey.Key, args.Route, args.TailscaleTags, args.EnableSSH).ApplyT(
 		func(args []interface{}) (string, error) {
 			d := UserDataArgs{
 				AuthKey:       args[0].(string),
 				Route:         args[1].(string),
 				TailscaleTags: args[2].([]string),
+				EnableSSH:     args[3].(bool),
 			}
 
 			var userDataBytes bytes.Buffer

--- a/provider/pkg/provider/azure/userdata.tmpl
+++ b/provider/pkg/provider/azure/userdata.tmpl
@@ -13,4 +13,4 @@ echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO 
 sudo apt-get update
 sudo apt-get install azure-cli tailscale
 
-sudo tailscale up --advertise-tags="{{ .JoinedTags }}" --advertise-routes="{{ .Route }}" --authkey="{{ .AuthKey }}" --host-routes --accept-dns=false
+sudo tailscale up --ssh="{{ .EnableSSH }} --advertise-tags="{{ .JoinedTags }}" --advertise-routes="{{ .Route }}" --authkey="{{ .AuthKey }}" --host-routes --accept-dns=false


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 792bfec1dafbcd2d4b6166fb24f2677201312480.  | 
|--------|--------|

### Summary:
This PR introduces the ability to enable SSH for Tailscale in AWS and Azure by adding the `EnableSSH` field to relevant structs and updating the `NewBastion` function in both `aws/bastion.go` and `azure/bastion.go`.

**Key points**:
- Added `EnableSSH` field to `BastionArgs` and `UserDataArgs` structs in `aws/bastion.go` and `azure/bastion.go`.
- Updated `NewBastion` function in both files to include `args.EnableSSH` in the `pulumi.All` function call and in the `UserDataArgs` struct initialization.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
