### PR TITLE
allow using public subnets

### DIFF
--- a/examples/aws/py/__main__.py
+++ b/examples/aws/py/__main__.py
@@ -7,20 +7,18 @@ import lbrlabs_pulumi_tailscalebastion as tailscale
 vpc = awsx.ec2.Vpc(
     "example",
     cidr_block="172.20.0.0/22",
-#     nat_gateways=awsx.ec2.NatGatewayConfigurationArgs(
-#         strategy=awsx.ec2.NatGatewayStrategy.NONE
-#     ),
 )
 
 bastion = tailscale.aws.Bastion(
     "example",
     vpc_id=vpc.vpc_id,
-    subnet_ids=vpc.private_subnet_ids,
+    subnet_ids=vpc.public_subnet_ids,
     route="172.20.0.0/22",
     tailscale_tags=["tag:bastion"],
     region="us-west-2",
     high_availability=True,
     enable_ssh=True,
+    public=True,
 )
 
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -58,6 +58,10 @@ resources:
   tailscale-bastion:aws:Bastion:
     isComponent: true
     inputProperties:
+      public:
+        type: boolean
+        description: "Whether the bastion is going in public subnets."
+        default: false
       enableSSH:
         type: boolean
         description: "Whether to enable SSH access to the bastion."

--- a/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
+++ b/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
@@ -73,6 +73,12 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
         public Input<string>? InstanceType { get; set; }
 
         /// <summary>
+        /// Whether the bastion is going in public subnets.
+        /// </summary>
+        [Input("public")]
+        public Input<bool>? Public { get; set; }
+
+        /// <summary>
         /// The AWS region you're using.
         /// </summary>
         [Input("region", required: true)]
@@ -118,6 +124,7 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
         {
             EnableSSH = true;
             HighAvailability = false;
+            Public = false;
         }
         public static new BastionArgs Empty => new BastionArgs();
     }

--- a/sdk/go/bastion/aws/bastion.go
+++ b/sdk/go/bastion/aws/bastion.go
@@ -50,6 +50,9 @@ func NewBastion(ctx *pulumi.Context,
 	if args.HighAvailability == nil {
 		args.HighAvailability = pulumi.Bool(false)
 	}
+	if args.Public == nil {
+		args.Public = pulumi.BoolPtr(false)
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Bastion
 	err := ctx.RegisterRemoteComponentResource("tailscale-bastion:aws:Bastion", name, args, &resource, opts...)
@@ -66,6 +69,8 @@ type bastionArgs struct {
 	HighAvailability bool `pulumi:"highAvailability"`
 	// The EC2 instance type to use for the bastion.
 	InstanceType *string `pulumi:"instanceType"`
+	// Whether the bastion is going in public subnets.
+	Public *bool `pulumi:"public"`
 	// The AWS region you're using.
 	Region string `pulumi:"region"`
 	// The route you'd like to advertise via tailscale.
@@ -86,6 +91,8 @@ type BastionArgs struct {
 	HighAvailability pulumi.BoolInput
 	// The EC2 instance type to use for the bastion.
 	InstanceType pulumi.StringPtrInput
+	// Whether the bastion is going in public subnets.
+	Public pulumi.BoolPtrInput
 	// The AWS region you're using.
 	Region pulumi.StringInput
 	// The route you'd like to advertise via tailscale.

--- a/sdk/nodejs/aws/bastion.ts
+++ b/sdk/nodejs/aws/bastion.ts
@@ -60,6 +60,7 @@ export class Bastion extends pulumi.ComponentResource {
             resourceInputs["enableSSH"] = (args ? args.enableSSH : undefined) ?? true;
             resourceInputs["highAvailability"] = (args ? args.highAvailability : undefined) ?? false;
             resourceInputs["instanceType"] = args ? args.instanceType : undefined;
+            resourceInputs["public"] = (args ? args.public : undefined) ?? false;
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["route"] = args ? args.route : undefined;
             resourceInputs["subnetIds"] = args ? args.subnetIds : undefined;
@@ -92,6 +93,10 @@ export interface BastionArgs {
      * The EC2 instance type to use for the bastion.
      */
     instanceType?: pulumi.Input<string>;
+    /**
+     * Whether the bastion is going in public subnets.
+     */
+    public?: pulumi.Input<boolean>;
     /**
      * The AWS region you're using.
      */

--- a/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
+++ b/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
@@ -21,7 +21,8 @@ class BastionArgs:
                  tailscale_tags: pulumi.Input[Sequence[pulumi.Input[str]]],
                  vpc_id: pulumi.Input[str],
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
-                 instance_type: Optional[pulumi.Input[str]] = None):
+                 instance_type: Optional[pulumi.Input[str]] = None,
+                 public: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a Bastion resource.
         :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
@@ -32,6 +33,7 @@ class BastionArgs:
         :param pulumi.Input[str] vpc_id: The VPC the Bastion should be created in.
         :param pulumi.Input[bool] enable_ssh: Whether to enable SSH access to the bastion.
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
+        :param pulumi.Input[bool] public: Whether the bastion is going in public subnets.
         """
         if high_availability is None:
             high_availability = False
@@ -47,6 +49,10 @@ class BastionArgs:
             pulumi.set(__self__, "enable_ssh", enable_ssh)
         if instance_type is not None:
             pulumi.set(__self__, "instance_type", instance_type)
+        if public is None:
+            public = False
+        if public is not None:
+            pulumi.set(__self__, "public", public)
 
     @property
     @pulumi.getter(name="highAvailability")
@@ -144,6 +150,18 @@ class BastionArgs:
     def instance_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "instance_type", value)
 
+    @property
+    @pulumi.getter
+    def public(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether the bastion is going in public subnets.
+        """
+        return pulumi.get(self, "public")
+
+    @public.setter
+    def public(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "public", value)
+
 
 class Bastion(pulumi.ComponentResource):
     @overload
@@ -153,6 +171,7 @@ class Bastion(pulumi.ComponentResource):
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
                  high_availability: Optional[pulumi.Input[bool]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
+                 public: Optional[pulumi.Input[bool]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  route: Optional[pulumi.Input[str]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -166,6 +185,7 @@ class Bastion(pulumi.ComponentResource):
         :param pulumi.Input[bool] enable_ssh: Whether to enable SSH access to the bastion.
         :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
+        :param pulumi.Input[bool] public: Whether the bastion is going in public subnets.
         :param pulumi.Input[str] region: The AWS region you're using.
         :param pulumi.Input[str] route: The route you'd like to advertise via tailscale.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The subnet Ids to launch instances in.
@@ -198,6 +218,7 @@ class Bastion(pulumi.ComponentResource):
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
                  high_availability: Optional[pulumi.Input[bool]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
+                 public: Optional[pulumi.Input[bool]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  route: Optional[pulumi.Input[str]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -223,6 +244,9 @@ class Bastion(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'high_availability'")
             __props__.__dict__["high_availability"] = high_availability
             __props__.__dict__["instance_type"] = instance_type
+            if public is None:
+                public = False
+            __props__.__dict__["public"] = public
             if region is None and not opts.urn:
                 raise TypeError("Missing required property 'region'")
             __props__.__dict__["region"] = region


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit ecf1e2a7ab2970a0da134d9f551267f80e1356ce.  | 
|--------|--------|

### Summary:
This PR enables the use of public subnets for the bastion by adding a `public` argument to `BastionArgs` and updating the `NewBastion` function and example accordingly.

**Key points**:
- Added `public` argument to `BastionArgs` in multiple languages.
- Updated `NewBastion` function to open UDP port if `public` is `true`.
- Updated example to use public subnets.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
