### PR TITLE
feat(bastion): add support for app connectors, exit nodes, and configurable tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   prerequisites:
@@ -161,7 +161,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   publish:
@@ -202,7 +202,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   publish_sdk:
@@ -280,7 +280,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   test:
@@ -365,7 +365,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
 name: main

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   prerequisites:
@@ -162,7 +162,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   publish:
@@ -203,7 +203,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   publish_sdk:
@@ -281,7 +281,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   test:
@@ -366,7 +366,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
 name: prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   prerequisites:
@@ -161,7 +161,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   publish:
@@ -202,7 +202,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   publish_sdk:
@@ -280,7 +280,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   test:
@@ -365,7 +365,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
 name: release

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   comment-notification:
@@ -187,7 +187,7 @@ jobs:
         goversion:
         - 1.21.x
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
   test:
@@ -276,7 +276,7 @@ jobs:
         - dotnet
         - go
         nodeversion:
-        - 18.x
+        - 21.x
         pythonversion:
         - "3.7"
 name: run-acceptance-tests

--- a/provider/pkg/provider/aws/bastion.go
+++ b/provider/pkg/provider/aws/bastion.go
@@ -43,17 +43,13 @@ type UserDataArgs struct {
 	ParameterName      string
 	Route              string
 	Region             string
-	TailscaleTags      []string
+	TailscaleTags      string
 	EnableSSH          bool
 	EnableExitNode     bool
 	EnableAppConnector bool
 	Hostname           string
 }
 
-// Join the tags into a CSV
-func (uda *UserDataArgs) JoinedTags() string {
-	return strings.Join(uda.TailscaleTags, ",")
-}
 
 // The Bastion component resource.
 type Bastion struct {
@@ -281,11 +277,14 @@ func NewBastion(ctx *pulumi.Context,
 
 	data := pulumi.All(tailnetKeySsmParameter.Name, args.Route, args.Region, args.TailscaleTags, args.EnableSSH, hostname, args.EnableExitNode, args.EnableAppConnector).ApplyT(
 		func(args []interface{}) (string, error) {
+
+        	tagCSV := strings.Join(args[3].([]string), ",")
+
 			d := UserDataArgs{
 				ParameterName:      args[0].(string),
 				Route:              args[1].(string),
 				Region:             args[2].(string),
-				TailscaleTags:      args[3].([]string),
+				TailscaleTags:      tagCSV,
 				EnableSSH:          args[4].(bool),
 				Hostname:           args[5].(string),
 				EnableExitNode:     args[6].(bool),

--- a/provider/pkg/provider/aws/userdata.tmpl
+++ b/provider/pkg/provider/aws/userdata.tmpl
@@ -18,4 +18,4 @@ sudo yum-config-manager --add-repo https://pkgs.tailscale.com/stable/amazon-linu
 sudo yum install tailscale -y
 sudo systemctl enable --now tailscaled
 sleep 10
-sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags=tag:bastion --advertise-routes="{{ .Route }}" --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes
+sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags="{{ .TailscaleTags}}" --advertise-routes="{{ .Route }}" --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes

--- a/provider/pkg/provider/aws/userdata.tmpl
+++ b/provider/pkg/provider/aws/userdata.tmpl
@@ -18,4 +18,4 @@ sudo yum-config-manager --add-repo https://pkgs.tailscale.com/stable/amazon-linu
 sudo yum install tailscale -y
 sudo systemctl enable --now tailscaled
 sleep 10
-sudo tailscale up --ssh="{{ .EnableSSH }}" --advertise-tags=tag:bastion --advertise-routes="{{ .Route }}" --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes
+sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags=tag:bastion --advertise-routes="{{ .Route }}" --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes

--- a/schema.yaml
+++ b/schema.yaml
@@ -183,6 +183,8 @@ language:
       "@pulumi/tailscale": "^0.11.0"
     devDependencies:
       typescript: "^3.7.0"
+      glob: "^7.1.2"
+      minimatch: "^3.1.2"
     packageName: "@lbrlabs/pulumi-tailscalebastion"
   python:
     packageName: "lbrlabs_pulumi_tailscalebastion"

--- a/schema.yaml
+++ b/schema.yaml
@@ -6,6 +6,12 @@ description: "A Pulumi package for creating a tailscale bastion in AWS."
 repository: "https://github.com/lbrlabs/pulumi-tailscale-bastion"
 publisher: "lbrlabs"
 displayname: "tailscale-bastion"
+keywords:
+  - aws
+  - tailscale
+  - lbrlabs
+  - kind/component
+  - category/network
 resources:
   tailscale-bastion:azure:Bastion:
     isComponent: true

--- a/schema.yaml
+++ b/schema.yaml
@@ -183,8 +183,8 @@ language:
       "@pulumi/tailscale": "^0.11.0"
     devDependencies:
       typescript: "^3.7.0"
-      glob: "^7.1.2"
-      minimatch: "^3.1.2"
+      glob: "^9.0.0"
+      minimatch: "^5.0.0"
     packageName: "@lbrlabs/pulumi-tailscalebastion"
   python:
     packageName: "lbrlabs_pulumi_tailscalebastion"

--- a/schema.yaml
+++ b/schema.yaml
@@ -58,6 +58,9 @@ resources:
   tailscale-bastion:aws:Bastion:
     isComponent: true
     inputProperties:
+      hostname:
+        type: string
+        description: "The hostname of the bastion."
       public:
         type: boolean
         description: "Whether the bastion is going in public subnets."
@@ -66,6 +69,14 @@ resources:
         type: boolean
         description: "Whether to enable SSH access to the bastion."
         default: true
+      enableAppConnector:
+        type: boolean
+        description: "Whether the bastion advertises itself as an app connector."
+        default: false
+      enableExitNode:
+        type: boolean
+        description: "Whether the subnet router can advertise itself as an exit node."
+        default: false
       highAvailability:
         type: boolean
         description: "Whether the bastion should be highly available."

--- a/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
+++ b/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
@@ -55,6 +55,18 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
     public sealed class BastionArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// Whether the bastion advertises itself as an app connector.
+        /// </summary>
+        [Input("enableAppConnector")]
+        public Input<bool>? EnableAppConnector { get; set; }
+
+        /// <summary>
+        /// Whether the subnet router can advertise itself as an exit node.
+        /// </summary>
+        [Input("enableExitNode")]
+        public Input<bool>? EnableExitNode { get; set; }
+
+        /// <summary>
         /// Whether to enable SSH access to the bastion.
         /// </summary>
         [Input("enableSSH")]
@@ -65,6 +77,12 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
         /// </summary>
         [Input("highAvailability", required: true)]
         public Input<bool> HighAvailability { get; set; } = null!;
+
+        /// <summary>
+        /// The hostname of the bastion.
+        /// </summary>
+        [Input("hostname")]
+        public Input<string>? Hostname { get; set; }
 
         /// <summary>
         /// The EC2 instance type to use for the bastion.
@@ -122,6 +140,8 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
 
         public BastionArgs()
         {
+            EnableAppConnector = false;
+            EnableExitNode = false;
             EnableSSH = true;
             HighAvailability = false;
             Public = false;

--- a/sdk/go/bastion/aws/bastion.go
+++ b/sdk/go/bastion/aws/bastion.go
@@ -44,6 +44,12 @@ func NewBastion(ctx *pulumi.Context,
 	if args.VpcId == nil {
 		return nil, errors.New("invalid value for required argument 'VpcId'")
 	}
+	if args.EnableAppConnector == nil {
+		args.EnableAppConnector = pulumi.BoolPtr(false)
+	}
+	if args.EnableExitNode == nil {
+		args.EnableExitNode = pulumi.BoolPtr(false)
+	}
 	if args.EnableSSH == nil {
 		args.EnableSSH = pulumi.BoolPtr(true)
 	}
@@ -63,10 +69,16 @@ func NewBastion(ctx *pulumi.Context,
 }
 
 type bastionArgs struct {
+	// Whether the bastion advertises itself as an app connector.
+	EnableAppConnector *bool `pulumi:"enableAppConnector"`
+	// Whether the subnet router can advertise itself as an exit node.
+	EnableExitNode *bool `pulumi:"enableExitNode"`
 	// Whether to enable SSH access to the bastion.
 	EnableSSH *bool `pulumi:"enableSSH"`
 	// Whether the bastion should be highly available.
 	HighAvailability bool `pulumi:"highAvailability"`
+	// The hostname of the bastion.
+	Hostname *string `pulumi:"hostname"`
 	// The EC2 instance type to use for the bastion.
 	InstanceType *string `pulumi:"instanceType"`
 	// Whether the bastion is going in public subnets.
@@ -85,10 +97,16 @@ type bastionArgs struct {
 
 // The set of arguments for constructing a Bastion resource.
 type BastionArgs struct {
+	// Whether the bastion advertises itself as an app connector.
+	EnableAppConnector pulumi.BoolPtrInput
+	// Whether the subnet router can advertise itself as an exit node.
+	EnableExitNode pulumi.BoolPtrInput
 	// Whether to enable SSH access to the bastion.
 	EnableSSH pulumi.BoolPtrInput
 	// Whether the bastion should be highly available.
 	HighAvailability pulumi.BoolInput
+	// The hostname of the bastion.
+	Hostname pulumi.StringPtrInput
 	// The EC2 instance type to use for the bastion.
 	InstanceType pulumi.StringPtrInput
 	// Whether the bastion is going in public subnets.

--- a/sdk/nodejs/aws/bastion.ts
+++ b/sdk/nodejs/aws/bastion.ts
@@ -57,8 +57,11 @@ export class Bastion extends pulumi.ComponentResource {
             if ((!args || args.vpcId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'vpcId'");
             }
+            resourceInputs["enableAppConnector"] = (args ? args.enableAppConnector : undefined) ?? false;
+            resourceInputs["enableExitNode"] = (args ? args.enableExitNode : undefined) ?? false;
             resourceInputs["enableSSH"] = (args ? args.enableSSH : undefined) ?? true;
             resourceInputs["highAvailability"] = (args ? args.highAvailability : undefined) ?? false;
+            resourceInputs["hostname"] = args ? args.hostname : undefined;
             resourceInputs["instanceType"] = args ? args.instanceType : undefined;
             resourceInputs["public"] = (args ? args.public : undefined) ?? false;
             resourceInputs["region"] = args ? args.region : undefined;
@@ -82,6 +85,14 @@ export class Bastion extends pulumi.ComponentResource {
  */
 export interface BastionArgs {
     /**
+     * Whether the bastion advertises itself as an app connector.
+     */
+    enableAppConnector?: pulumi.Input<boolean>;
+    /**
+     * Whether the subnet router can advertise itself as an exit node.
+     */
+    enableExitNode?: pulumi.Input<boolean>;
+    /**
      * Whether to enable SSH access to the bastion.
      */
     enableSSH?: pulumi.Input<boolean>;
@@ -89,6 +100,10 @@ export interface BastionArgs {
      * Whether the bastion should be highly available.
      */
     highAvailability: pulumi.Input<boolean>;
+    /**
+     * The hostname of the bastion.
+     */
+    hostname?: pulumi.Input<string>;
     /**
      * The EC2 instance type to use for the bastion.
      */

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -22,6 +22,8 @@
     },
     "devDependencies": {
         "@types/node": "^14",
+        "glob": "^7.1.2",
+        "minimatch": "^3.1.2",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -22,8 +22,8 @@
     },
     "devDependencies": {
         "@types/node": "^14",
-        "glob": "^7.1.2",
-        "minimatch": "^3.1.2",
+        "glob": "^9.0.0",
+        "minimatch": "^5.0.0",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,13 @@
 {
     "name": "@lbrlabs/pulumi-tailscalebastion",
     "version": "${VERSION}",
+    "keywords": [
+        "aws",
+        "tailscale",
+        "lbrlabs",
+        "kind/component",
+        "category/network"
+    ],
     "repository": "https://github.com/lbrlabs/pulumi-tailscale-bastion",
     "scripts": {
         "build": "tsc"

--- a/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
+++ b/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
@@ -20,7 +20,10 @@ class BastionArgs:
                  subnet_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  tailscale_tags: pulumi.Input[Sequence[pulumi.Input[str]]],
                  vpc_id: pulumi.Input[str],
+                 enable_app_connector: Optional[pulumi.Input[bool]] = None,
+                 enable_exit_node: Optional[pulumi.Input[bool]] = None,
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
+                 hostname: Optional[pulumi.Input[str]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  public: Optional[pulumi.Input[bool]] = None):
         """
@@ -31,7 +34,10 @@ class BastionArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The subnet Ids to launch instances in.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tailscale_tags: The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
         :param pulumi.Input[str] vpc_id: The VPC the Bastion should be created in.
+        :param pulumi.Input[bool] enable_app_connector: Whether the bastion advertises itself as an app connector.
+        :param pulumi.Input[bool] enable_exit_node: Whether the subnet router can advertise itself as an exit node.
         :param pulumi.Input[bool] enable_ssh: Whether to enable SSH access to the bastion.
+        :param pulumi.Input[str] hostname: The hostname of the bastion.
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
         :param pulumi.Input[bool] public: Whether the bastion is going in public subnets.
         """
@@ -43,10 +49,20 @@ class BastionArgs:
         pulumi.set(__self__, "subnet_ids", subnet_ids)
         pulumi.set(__self__, "tailscale_tags", tailscale_tags)
         pulumi.set(__self__, "vpc_id", vpc_id)
+        if enable_app_connector is None:
+            enable_app_connector = False
+        if enable_app_connector is not None:
+            pulumi.set(__self__, "enable_app_connector", enable_app_connector)
+        if enable_exit_node is None:
+            enable_exit_node = False
+        if enable_exit_node is not None:
+            pulumi.set(__self__, "enable_exit_node", enable_exit_node)
         if enable_ssh is None:
             enable_ssh = True
         if enable_ssh is not None:
             pulumi.set(__self__, "enable_ssh", enable_ssh)
+        if hostname is not None:
+            pulumi.set(__self__, "hostname", hostname)
         if instance_type is not None:
             pulumi.set(__self__, "instance_type", instance_type)
         if public is None:
@@ -127,6 +143,30 @@ class BastionArgs:
         pulumi.set(self, "vpc_id", value)
 
     @property
+    @pulumi.getter(name="enableAppConnector")
+    def enable_app_connector(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether the bastion advertises itself as an app connector.
+        """
+        return pulumi.get(self, "enable_app_connector")
+
+    @enable_app_connector.setter
+    def enable_app_connector(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_app_connector", value)
+
+    @property
+    @pulumi.getter(name="enableExitNode")
+    def enable_exit_node(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether the subnet router can advertise itself as an exit node.
+        """
+        return pulumi.get(self, "enable_exit_node")
+
+    @enable_exit_node.setter
+    def enable_exit_node(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_exit_node", value)
+
+    @property
     @pulumi.getter(name="enableSSH")
     def enable_ssh(self) -> Optional[pulumi.Input[bool]]:
         """
@@ -137,6 +177,18 @@ class BastionArgs:
     @enable_ssh.setter
     def enable_ssh(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "enable_ssh", value)
+
+    @property
+    @pulumi.getter
+    def hostname(self) -> Optional[pulumi.Input[str]]:
+        """
+        The hostname of the bastion.
+        """
+        return pulumi.get(self, "hostname")
+
+    @hostname.setter
+    def hostname(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "hostname", value)
 
     @property
     @pulumi.getter(name="instanceType")
@@ -168,8 +220,11 @@ class Bastion(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 enable_app_connector: Optional[pulumi.Input[bool]] = None,
+                 enable_exit_node: Optional[pulumi.Input[bool]] = None,
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
                  high_availability: Optional[pulumi.Input[bool]] = None,
+                 hostname: Optional[pulumi.Input[str]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  public: Optional[pulumi.Input[bool]] = None,
                  region: Optional[pulumi.Input[str]] = None,
@@ -182,8 +237,11 @@ class Bastion(pulumi.ComponentResource):
         Create a Bastion resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] enable_app_connector: Whether the bastion advertises itself as an app connector.
+        :param pulumi.Input[bool] enable_exit_node: Whether the subnet router can advertise itself as an exit node.
         :param pulumi.Input[bool] enable_ssh: Whether to enable SSH access to the bastion.
         :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
+        :param pulumi.Input[str] hostname: The hostname of the bastion.
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
         :param pulumi.Input[bool] public: Whether the bastion is going in public subnets.
         :param pulumi.Input[str] region: The AWS region you're using.
@@ -215,8 +273,11 @@ class Bastion(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 enable_app_connector: Optional[pulumi.Input[bool]] = None,
+                 enable_exit_node: Optional[pulumi.Input[bool]] = None,
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
                  high_availability: Optional[pulumi.Input[bool]] = None,
+                 hostname: Optional[pulumi.Input[str]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  public: Optional[pulumi.Input[bool]] = None,
                  region: Optional[pulumi.Input[str]] = None,
@@ -235,6 +296,12 @@ class Bastion(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = BastionArgs.__new__(BastionArgs)
 
+            if enable_app_connector is None:
+                enable_app_connector = False
+            __props__.__dict__["enable_app_connector"] = enable_app_connector
+            if enable_exit_node is None:
+                enable_exit_node = False
+            __props__.__dict__["enable_exit_node"] = enable_exit_node
             if enable_ssh is None:
                 enable_ssh = True
             __props__.__dict__["enable_ssh"] = enable_ssh
@@ -243,6 +310,7 @@ class Bastion(pulumi.ComponentResource):
             if high_availability is None and not opts.urn:
                 raise TypeError("Missing required property 'high_availability'")
             __props__.__dict__["high_availability"] = high_availability
+            __props__.__dict__["hostname"] = hostname
             __props__.__dict__["instance_type"] = instance_type
             if public is None:
                 public = False

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -23,6 +23,7 @@ setup(name='lbrlabs_pulumi_tailscalebastion',
       description="A Pulumi package for creating a tailscale bastion in AWS.",
       long_description=readme(),
       long_description_content_type='text/markdown',
+      keywords='aws tailscale lbrlabs kind/component category/network',
       project_urls={
           'Repository': 'https://github.com/lbrlabs/pulumi-tailscale-bastion'
       },


### PR DESCRIPTION
- add support for app connectors and exit nodes
- make tags configurable


<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit efc6fdfc629c3c6b3f6a51a5a456ace12deecfda.  | 
|--------|--------|

### Summary:
This PR introduces support for app connectors and exit nodes in the bastion, makes tags configurable, and updates the `schema.yaml` file, SDKs, and Node.js version in GitHub workflows to reflect these changes.

**Key points**:
- Added support for app connectors and exit nodes in `BastionArgs` struct in `/provider/pkg/provider/aws/bastion.go`.
- Updated `UserDataArgs` struct to include new fields.
- Updated `NewBastion` function to handle new arguments.
- Updated `schema.yaml` to reflect new arguments.
- Updated SDKs for Dotnet, Go, Nodejs, and Python to include new arguments.
- Made tags configurable.
- Updated Node.js version in GitHub workflows from 18.x to 21.x.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
