### PR TITLE
feat(AWS/Azure): support for multiple routes

### DIFF
--- a/provider/pkg/provider/aws/bastion.go
+++ b/provider/pkg/provider/aws/bastion.go
@@ -6,9 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
-	"text/template"
-
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/autoscaling"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
@@ -16,6 +13,8 @@ import (
 	"github.com/pulumi/pulumi-tailscale/sdk/go/tailscale"
 	tls "github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"strings"
+	"text/template"
 )
 
 var (
@@ -28,7 +27,7 @@ type BastionArgs struct {
 	VpcID              pulumi.StringInput      `pulumi:"vpcId"`
 	SubnetIds          pulumi.StringArrayInput `pulumi:"subnetIds"`
 	TailscaleTags      pulumi.StringArrayInput `pulumi:"tailscaleTags"`
-	Route              pulumi.StringInput      `pulumi:"route"`
+	Routes             pulumi.StringArrayInput `pulumi:"routes"`
 	Region             pulumi.StringInput      `pulumi:"region"`
 	InstanceType       pulumi.StringInput      `pulumi:"instanceType"`
 	Hostname           pulumi.StringInput      `pulumi:"hostname"`
@@ -41,7 +40,7 @@ type BastionArgs struct {
 
 type UserDataArgs struct {
 	ParameterName      string
-	Route              string
+	Routes             string
 	Region             string
 	TailscaleTags      string
 	EnableSSH          bool
@@ -49,7 +48,6 @@ type UserDataArgs struct {
 	EnableAppConnector bool
 	Hostname           string
 }
-
 
 // The Bastion component resource.
 type Bastion struct {
@@ -275,14 +273,21 @@ func NewBastion(ctx *pulumi.Context,
 		MostRecent: pulumi.BoolPtr(true),
 	}, pulumi.Parent(component))
 
-	data := pulumi.All(tailnetKeySsmParameter.Name, args.Route, args.Region, args.TailscaleTags, args.EnableSSH, hostname, args.EnableExitNode, args.EnableAppConnector).ApplyT(
+	data := pulumi.All(tailnetKeySsmParameter.Name, args.Routes, args.Region, args.TailscaleTags, args.EnableSSH, hostname, args.EnableExitNode, args.EnableAppConnector).ApplyT(
 		func(args []interface{}) (string, error) {
 
-        	tagCSV := strings.Join(args[3].([]string), ",")
+			tagCSV := strings.Join(args[3].([]string), ",")
+
+			var routesCsv string
+			if len(args[1].([]string)) != 0 {
+				routesCsv = strings.Join(args[1].([]string), ",")
+			} else {
+				routesCsv = ""
+			}
 
 			d := UserDataArgs{
 				ParameterName:      args[0].(string),
-				Route:              args[1].(string),
+				Routes:             routesCsv,
 				Region:             args[2].(string),
 				TailscaleTags:      tagCSV,
 				EnableSSH:          args[4].(bool),

--- a/provider/pkg/provider/aws/bastion.go
+++ b/provider/pkg/provider/aws/bastion.go
@@ -279,8 +279,10 @@ func NewBastion(ctx *pulumi.Context,
 			tagCSV := strings.Join(args[3].([]string), ",")
 
 			var routesCsv string
-			if len(args[1].([]string)) != 0 {
-				routesCsv = strings.Join(args[1].([]string), ",")
+
+			if args[1] != nil {
+				routes := args[1].([]string)
+				routesCsv = strings.Join(routes, ",")
 			} else {
 				routesCsv = ""
 			}

--- a/provider/pkg/provider/aws/userdata.tmpl
+++ b/provider/pkg/provider/aws/userdata.tmpl
@@ -18,4 +18,4 @@ sudo yum-config-manager --add-repo https://pkgs.tailscale.com/stable/amazon-linu
 sudo yum install tailscale -y
 sudo systemctl enable --now tailscaled
 sleep 10
-sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags="{{ .TailscaleTags}}" --advertise-routes="{{ .Route }}" --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes
+sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags="{{ .TailscaleTags}}" {{if .Routes}} --advertise-routes="{{ .Routes }}"{{end}} --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes

--- a/provider/pkg/provider/aws/userdata.tmpl
+++ b/provider/pkg/provider/aws/userdata.tmpl
@@ -18,4 +18,4 @@ sudo yum-config-manager --add-repo https://pkgs.tailscale.com/stable/amazon-linu
 sudo yum install tailscale -y
 sudo systemctl enable --now tailscaled
 sleep 10
-sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags="{{ .TailscaleTags}}" {{if .Routes}} --advertise-routes="{{ .Routes }}"{{end}} --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes
+sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags="{{ .TailscaleTags}}" {{if .Routes}}--advertise-routes="{{ .Routes }}"{{end}} --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes

--- a/provider/pkg/provider/azure/userdata.tmpl
+++ b/provider/pkg/provider/azure/userdata.tmpl
@@ -13,4 +13,4 @@ echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO 
 sudo apt-get update
 sudo apt-get install azure-cli tailscale
 
-sudo tailscale up --ssh="{{ .EnableSSH }}" --advertise-tags="{{ .JoinedTags }}" --advertise-routes="{{ .Route }}" --authkey="{{ .AuthKey }}" --host-routes --accept-dns=false
+sudo tailscale up --advertise-connector="{{ .EnableAppConnector }}" --advertise-exit-node="{{ .EnableExitNode }}" --hostname="{{ .Hostname}}" --ssh="{{ .EnableSSH }}" --advertise-tags="{{ .TailscaleTags}}" {{if .Routes}}--advertise-routes="{{ .Routes }}"{{end}} --authkey=$(aws ssm get-parameter --name {{.ParameterName}} --region {{.Region}} --with-decryption | jq .Parameter.Value -r) --host-routes

--- a/schema.yaml
+++ b/schema.yaml
@@ -100,9 +100,11 @@ resources:
         items:
           type: string
         description: "The subnet Ids to launch instances in."
-      route:
-        type: string
-        description: "The route you'd like to advertise via tailscale."
+      routes:
+        type: array
+        items:
+          type: string
+        description: "The routes you'd like to advertise via tailscale."
       region:
         type: string
         description: "The AWS region you're using."
@@ -113,7 +115,6 @@ resources:
       - highAvailability
       - vpcId
       - subnetIds
-      - route
       - region
       - tailscaleTags
     properties:

--- a/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
+++ b/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
@@ -102,11 +102,17 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
         [Input("region", required: true)]
         public Input<string> Region { get; set; } = null!;
 
+        [Input("routes")]
+        private InputList<string>? _routes;
+
         /// <summary>
-        /// The route you'd like to advertise via tailscale.
+        /// The routes you'd like to advertise via tailscale.
         /// </summary>
-        [Input("route", required: true)]
-        public Input<string> Route { get; set; } = null!;
+        public InputList<string> Routes
+        {
+            get => _routes ?? (_routes = new InputList<string>());
+            set => _routes = value;
+        }
 
         [Input("subnetIds", required: true)]
         private InputList<string>? _subnetIds;

--- a/sdk/go/bastion/aws/bastion.go
+++ b/sdk/go/bastion/aws/bastion.go
@@ -32,9 +32,6 @@ func NewBastion(ctx *pulumi.Context,
 	if args.Region == nil {
 		return nil, errors.New("invalid value for required argument 'Region'")
 	}
-	if args.Route == nil {
-		return nil, errors.New("invalid value for required argument 'Route'")
-	}
 	if args.SubnetIds == nil {
 		return nil, errors.New("invalid value for required argument 'SubnetIds'")
 	}
@@ -85,8 +82,8 @@ type bastionArgs struct {
 	Public *bool `pulumi:"public"`
 	// The AWS region you're using.
 	Region string `pulumi:"region"`
-	// The route you'd like to advertise via tailscale.
-	Route string `pulumi:"route"`
+	// The routes you'd like to advertise via tailscale.
+	Routes []string `pulumi:"routes"`
 	// The subnet Ids to launch instances in.
 	SubnetIds []string `pulumi:"subnetIds"`
 	// The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
@@ -113,8 +110,8 @@ type BastionArgs struct {
 	Public pulumi.BoolPtrInput
 	// The AWS region you're using.
 	Region pulumi.StringInput
-	// The route you'd like to advertise via tailscale.
-	Route pulumi.StringInput
+	// The routes you'd like to advertise via tailscale.
+	Routes pulumi.StringArrayInput
 	// The subnet Ids to launch instances in.
 	SubnetIds pulumi.StringArrayInput
 	// The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.

--- a/sdk/nodejs/aws/bastion.ts
+++ b/sdk/nodejs/aws/bastion.ts
@@ -45,9 +45,6 @@ export class Bastion extends pulumi.ComponentResource {
             if ((!args || args.region === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'region'");
             }
-            if ((!args || args.route === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'route'");
-            }
             if ((!args || args.subnetIds === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'subnetIds'");
             }
@@ -65,7 +62,7 @@ export class Bastion extends pulumi.ComponentResource {
             resourceInputs["instanceType"] = args ? args.instanceType : undefined;
             resourceInputs["public"] = (args ? args.public : undefined) ?? false;
             resourceInputs["region"] = args ? args.region : undefined;
-            resourceInputs["route"] = args ? args.route : undefined;
+            resourceInputs["routes"] = args ? args.routes : undefined;
             resourceInputs["subnetIds"] = args ? args.subnetIds : undefined;
             resourceInputs["tailscaleTags"] = args ? args.tailscaleTags : undefined;
             resourceInputs["vpcId"] = args ? args.vpcId : undefined;
@@ -117,9 +114,9 @@ export interface BastionArgs {
      */
     region: pulumi.Input<string>;
     /**
-     * The route you'd like to advertise via tailscale.
+     * The routes you'd like to advertise via tailscale.
      */
-    route: pulumi.Input<string>;
+    routes?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * The subnet Ids to launch instances in.
      */

--- a/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
+++ b/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
@@ -16,7 +16,6 @@ class BastionArgs:
     def __init__(__self__, *,
                  high_availability: Optional[pulumi.Input[bool]] = None,
                  region: pulumi.Input[str],
-                 route: pulumi.Input[str],
                  subnet_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  tailscale_tags: pulumi.Input[Sequence[pulumi.Input[str]]],
                  vpc_id: pulumi.Input[str],
@@ -25,12 +24,12 @@ class BastionArgs:
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
                  hostname: Optional[pulumi.Input[str]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
-                 public: Optional[pulumi.Input[bool]] = None):
+                 public: Optional[pulumi.Input[bool]] = None,
+                 routes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Bastion resource.
         :param pulumi.Input[bool] high_availability: Whether the bastion should be highly available.
         :param pulumi.Input[str] region: The AWS region you're using.
-        :param pulumi.Input[str] route: The route you'd like to advertise via tailscale.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The subnet Ids to launch instances in.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tailscale_tags: The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
         :param pulumi.Input[str] vpc_id: The VPC the Bastion should be created in.
@@ -40,12 +39,12 @@ class BastionArgs:
         :param pulumi.Input[str] hostname: The hostname of the bastion.
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
         :param pulumi.Input[bool] public: Whether the bastion is going in public subnets.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] routes: The routes you'd like to advertise via tailscale.
         """
         if high_availability is None:
             high_availability = False
         pulumi.set(__self__, "high_availability", high_availability)
         pulumi.set(__self__, "region", region)
-        pulumi.set(__self__, "route", route)
         pulumi.set(__self__, "subnet_ids", subnet_ids)
         pulumi.set(__self__, "tailscale_tags", tailscale_tags)
         pulumi.set(__self__, "vpc_id", vpc_id)
@@ -69,6 +68,8 @@ class BastionArgs:
             public = False
         if public is not None:
             pulumi.set(__self__, "public", public)
+        if routes is not None:
+            pulumi.set(__self__, "routes", routes)
 
     @property
     @pulumi.getter(name="highAvailability")
@@ -93,18 +94,6 @@ class BastionArgs:
     @region.setter
     def region(self, value: pulumi.Input[str]):
         pulumi.set(self, "region", value)
-
-    @property
-    @pulumi.getter
-    def route(self) -> pulumi.Input[str]:
-        """
-        The route you'd like to advertise via tailscale.
-        """
-        return pulumi.get(self, "route")
-
-    @route.setter
-    def route(self, value: pulumi.Input[str]):
-        pulumi.set(self, "route", value)
 
     @property
     @pulumi.getter(name="subnetIds")
@@ -214,6 +203,18 @@ class BastionArgs:
     def public(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "public", value)
 
+    @property
+    @pulumi.getter
+    def routes(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The routes you'd like to advertise via tailscale.
+        """
+        return pulumi.get(self, "routes")
+
+    @routes.setter
+    def routes(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "routes", value)
+
 
 class Bastion(pulumi.ComponentResource):
     @overload
@@ -228,7 +229,7 @@ class Bastion(pulumi.ComponentResource):
                  instance_type: Optional[pulumi.Input[str]] = None,
                  public: Optional[pulumi.Input[bool]] = None,
                  region: Optional[pulumi.Input[str]] = None,
-                 route: Optional[pulumi.Input[str]] = None,
+                 routes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tailscale_tags: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
@@ -245,7 +246,7 @@ class Bastion(pulumi.ComponentResource):
         :param pulumi.Input[str] instance_type: The EC2 instance type to use for the bastion.
         :param pulumi.Input[bool] public: Whether the bastion is going in public subnets.
         :param pulumi.Input[str] region: The AWS region you're using.
-        :param pulumi.Input[str] route: The route you'd like to advertise via tailscale.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] routes: The routes you'd like to advertise via tailscale.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The subnet Ids to launch instances in.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tailscale_tags: The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
         :param pulumi.Input[str] vpc_id: The VPC the Bastion should be created in.
@@ -281,7 +282,7 @@ class Bastion(pulumi.ComponentResource):
                  instance_type: Optional[pulumi.Input[str]] = None,
                  public: Optional[pulumi.Input[bool]] = None,
                  region: Optional[pulumi.Input[str]] = None,
-                 route: Optional[pulumi.Input[str]] = None,
+                 routes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tailscale_tags: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
@@ -318,9 +319,7 @@ class Bastion(pulumi.ComponentResource):
             if region is None and not opts.urn:
                 raise TypeError("Missing required property 'region'")
             __props__.__dict__["region"] = region
-            if route is None and not opts.urn:
-                raise TypeError("Missing required property 'route'")
-            __props__.__dict__["route"] = route
+            __props__.__dict__["routes"] = routes
             if subnet_ids is None and not opts.urn:
                 raise TypeError("Missing required property 'subnet_ids'")
             __props__.__dict__["subnet_ids"] = subnet_ids


### PR DESCRIPTION
- v1
- multiple routes support, azure appc and exit node


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2a92a789d59d945e61115bfb2452a4c6cba27a22.  | 
|--------|--------|

### Summary:
This PR introduces support for multiple routes in both AWS and Azure providers.

**Key points**:
- Updated `BastionArgs` and `UserDataArgs` in `aws/bastion.go` and `azure/bastion.go` to handle multiple routes.
- Updated user data templates for both AWS and Azure to handle multiple routes.
- Updated `schema.yaml` to reflect changes.
- Updated SDKs for Dotnet, Go, and Node.js.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
