### PR TITLE
feat(cloud-instances): enable IPv6 forwarding on eth0 for AWS and Azure

### DIFF
--- a/provider/pkg/provider/aws/userdata.tmpl
+++ b/provider/pkg/provider/aws/userdata.tmpl
@@ -8,6 +8,7 @@ sudo systemctl start amazon-ssm-agent
 
 echo "set some kernel values"
 sudo sysctl -w net.ipv4.ip_forward=1
+sudo sysctl -w net.ipv6.conf.eth0.forwarding=1
 
 echo "install jq"
 sudo yum install -y jq

--- a/provider/pkg/provider/aws/userdata.tmpl
+++ b/provider/pkg/provider/aws/userdata.tmpl
@@ -8,7 +8,7 @@ sudo systemctl start amazon-ssm-agent
 
 echo "set some kernel values"
 sudo sysctl -w net.ipv4.ip_forward=1
-sudo sysctl -w net.ipv6.conf.eth0.forwarding=1
+sudo sysctl -w net.ipv6.conf.all.forwarding=1
 
 echo "install jq"
 sudo yum install -y jq

--- a/provider/pkg/provider/azure/userdata.tmpl
+++ b/provider/pkg/provider/azure/userdata.tmpl
@@ -2,6 +2,7 @@
 
 echo "set some kernel values"
 sudo sysctl -w net.ipv4.ip_forward=1
+sudo sysctl -w net.ipv6.conf.eth0.forwarding=1
 
 echo "Installing Tailscale"
 curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null

--- a/provider/pkg/provider/azure/userdata.tmpl
+++ b/provider/pkg/provider/azure/userdata.tmpl
@@ -2,7 +2,7 @@
 
 echo "set some kernel values"
 sudo sysctl -w net.ipv4.ip_forward=1
-sudo sysctl -w net.ipv6.conf.eth0.forwarding=1
+sudo sysctl -w net.ipv6.conf.all.forwarding=1
 
 echo "Installing Tailscale"
 curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fa7022b5bb8d75fc92d3300a041ba5d75f472ade  | 
|--------|

### Summary:
This PR updates IPv6 forwarding to all interfaces and modifies `userdata.tmpl` files for AWS and Azure instances.

**Key points**:
- Enable IPv6 forwarding on all interfaces for both AWS and Azure instances.
- Update `userdata.tmpl` files for AWS and Azure to include the new sysctl command.
- Applied in `/provider/pkg/provider/aws/userdata.tmpl` and `/provider/pkg/provider/azure/userdata.tmpl`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
