### PR TITLE
feat: support ARM architecture and update to Amazon Linux 2023 in AWS Bastion

### DIFF
--- a/provider/pkg/provider/aws/bastion.go
+++ b/provider/pkg/provider/aws/bastion.go
@@ -257,6 +257,7 @@ func NewBastion(ctx *pulumi.Context,
 	if err != nil {
 		return nil, fmt.Errorf("error creating security group: %v", err)
 	}
+	
 
 	ami := ec2.LookupAmiOutput(ctx, ec2.LookupAmiOutputArgs{
 		Owners: pulumi.StringArray{
@@ -279,7 +280,7 @@ func NewBastion(ctx *pulumi.Context,
 			ec2.GetAmiFilterArgs{
 				Name: pulumi.String("name"),
 				Values: pulumi.StringArray{
-					pulumi.String("amzn2-ami-hvm*"),
+					pulumi.String("al2023-ami-*x86_64*"),
 				},
 			},
 		},

--- a/schema.yaml
+++ b/schema.yaml
@@ -120,6 +120,13 @@ resources:
       oauthClientSecret:
         type: string
         description: "An OAuth Client Secret to use for authenticating Tailscale clients."
+      architecture:
+        type: string
+        description: "The CPU architecture for the bastion (x86_64 or arm64)."
+        enum:
+          - x86_64
+          - arm64
+        default: x86_64
     requiredInputs:
       - highAvailability
       - vpcId

--- a/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
+++ b/sdk/dotnet/TailscaleBastion/Aws/Bastion.cs
@@ -55,6 +55,12 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
     public sealed class BastionArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// The CPU architecture for the bastion (x86_64 or arm64).
+        /// </summary>
+        [Input("architecture")]
+        public Input<string>? Architecture { get; set; }
+
+        /// <summary>
         /// Whether the bastion advertises itself as an app connector.
         /// </summary>
         [Input("enableAppConnector")]
@@ -152,6 +158,7 @@ namespace Lbrlabs.PulumiPackage.TailscaleBastion.Aws
 
         public BastionArgs()
         {
+            Architecture = "x86_64";
             EnableAppConnector = false;
             EnableExitNode = false;
             EnableSSH = true;

--- a/sdk/go/bastion/aws/bastion.go
+++ b/sdk/go/bastion/aws/bastion.go
@@ -40,6 +40,9 @@ func NewBastion(ctx *pulumi.Context,
 	if args.VpcId == nil {
 		return nil, errors.New("invalid value for required argument 'VpcId'")
 	}
+	if args.Architecture == nil {
+		args.Architecture = pulumi.StringPtr("x86_64")
+	}
 	if args.EnableAppConnector == nil {
 		args.EnableAppConnector = pulumi.BoolPtr(false)
 	}
@@ -65,6 +68,8 @@ func NewBastion(ctx *pulumi.Context,
 }
 
 type bastionArgs struct {
+	// The CPU architecture for the bastion (x86_64 or arm64).
+	Architecture *string `pulumi:"architecture"`
 	// Whether the bastion advertises itself as an app connector.
 	EnableAppConnector *bool `pulumi:"enableAppConnector"`
 	// Whether the subnet router can advertise itself as an exit node.
@@ -95,6 +100,8 @@ type bastionArgs struct {
 
 // The set of arguments for constructing a Bastion resource.
 type BastionArgs struct {
+	// The CPU architecture for the bastion (x86_64 or arm64).
+	Architecture pulumi.StringPtrInput
 	// Whether the bastion advertises itself as an app connector.
 	EnableAppConnector pulumi.BoolPtrInput
 	// Whether the subnet router can advertise itself as an exit node.

--- a/sdk/nodejs/aws/bastion.ts
+++ b/sdk/nodejs/aws/bastion.ts
@@ -54,6 +54,7 @@ export class Bastion extends pulumi.ComponentResource {
             if ((!args || args.vpcId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'vpcId'");
             }
+            resourceInputs["architecture"] = (args ? args.architecture : undefined) ?? "x86_64";
             resourceInputs["enableAppConnector"] = (args ? args.enableAppConnector : undefined) ?? false;
             resourceInputs["enableExitNode"] = (args ? args.enableExitNode : undefined) ?? false;
             resourceInputs["enableSSH"] = (args ? args.enableSSH : undefined) ?? true;
@@ -82,6 +83,10 @@ export class Bastion extends pulumi.ComponentResource {
  * The set of arguments for constructing a Bastion resource.
  */
 export interface BastionArgs {
+    /**
+     * The CPU architecture for the bastion (x86_64 or arm64).
+     */
+    architecture?: pulumi.Input<string>;
     /**
      * Whether the bastion advertises itself as an app connector.
      */

--- a/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
+++ b/sdk/python/lbrlabs_pulumi_tailscalebastion/aws/bastion.py
@@ -24,6 +24,7 @@ class BastionArgs:
                  subnet_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  tailscale_tags: pulumi.Input[Sequence[pulumi.Input[str]]],
                  vpc_id: pulumi.Input[str],
+                 architecture: Optional[pulumi.Input[str]] = None,
                  enable_app_connector: Optional[pulumi.Input[bool]] = None,
                  enable_exit_node: Optional[pulumi.Input[bool]] = None,
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
@@ -39,6 +40,7 @@ class BastionArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The subnet Ids to launch instances in.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tailscale_tags: The tags to apply to the tailnet device andauth key. This tag should be added to your oauth key and ACL.
         :param pulumi.Input[str] vpc_id: The VPC the Bastion should be created in.
+        :param pulumi.Input[str] architecture: The CPU architecture for the bastion (x86_64 or arm64).
         :param pulumi.Input[bool] enable_app_connector: Whether the bastion advertises itself as an app connector.
         :param pulumi.Input[bool] enable_exit_node: Whether the subnet router can advertise itself as an exit node.
         :param pulumi.Input[bool] enable_ssh: Whether to enable SSH access to the bastion.
@@ -55,6 +57,10 @@ class BastionArgs:
         pulumi.set(__self__, "subnet_ids", subnet_ids)
         pulumi.set(__self__, "tailscale_tags", tailscale_tags)
         pulumi.set(__self__, "vpc_id", vpc_id)
+        if architecture is None:
+            architecture = 'x86_64'
+        if architecture is not None:
+            pulumi.set(__self__, "architecture", architecture)
         if enable_app_connector is None:
             enable_app_connector = False
         if enable_app_connector is not None:
@@ -139,6 +145,18 @@ class BastionArgs:
     @vpc_id.setter
     def vpc_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "vpc_id", value)
+
+    @property
+    @pulumi.getter
+    def architecture(self) -> Optional[pulumi.Input[str]]:
+        """
+        The CPU architecture for the bastion (x86_64 or arm64).
+        """
+        return pulumi.get(self, "architecture")
+
+    @architecture.setter
+    def architecture(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "architecture", value)
 
     @property
     @pulumi.getter(name="enableAppConnector")
@@ -242,6 +260,7 @@ class Bastion(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 architecture: Optional[pulumi.Input[str]] = None,
                  enable_app_connector: Optional[pulumi.Input[bool]] = None,
                  enable_exit_node: Optional[pulumi.Input[bool]] = None,
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
@@ -260,6 +279,7 @@ class Bastion(pulumi.ComponentResource):
         Create a Bastion resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[str] architecture: The CPU architecture for the bastion (x86_64 or arm64).
         :param pulumi.Input[bool] enable_app_connector: Whether the bastion advertises itself as an app connector.
         :param pulumi.Input[bool] enable_exit_node: Whether the subnet router can advertise itself as an exit node.
         :param pulumi.Input[bool] enable_ssh: Whether to enable SSH access to the bastion.
@@ -297,6 +317,7 @@ class Bastion(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 architecture: Optional[pulumi.Input[str]] = None,
                  enable_app_connector: Optional[pulumi.Input[bool]] = None,
                  enable_exit_node: Optional[pulumi.Input[bool]] = None,
                  enable_ssh: Optional[pulumi.Input[bool]] = None,
@@ -321,6 +342,9 @@ class Bastion(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = BastionArgs.__new__(BastionArgs)
 
+            if architecture is None:
+                architecture = 'x86_64'
+            __props__.__dict__["architecture"] = architecture
             if enable_app_connector is None:
                 enable_app_connector = False
             __props__.__dict__["enable_app_connector"] = enable_app_connector


### PR DESCRIPTION
- **use amazon linux 2023**
- **support arm architecture**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for ARM architecture and update to Amazon Linux 2023 in AWS Bastion component, with changes in `bastion.go`, `schema.yaml`, and SDKs.
> 
>   - **Behavior**:
>     - Add `Architecture` field to `BastionArgs` in `bastion.go` to support `x86_64` and `arm64` architectures.
>     - Default architecture set to `x86_64` if not specified.
>     - Update AMI lookup to use Amazon Linux 2023 in `bastion.go`.
>     - Adjust default instance type to `t4g.micro` for `arm64` and `t3.micro` for `x86_64` in `bastion.go`.
>   - **Schema**:
>     - Add `architecture` property to `tailscale-bastion:aws:Bastion` in `schema.yaml` with default `x86_64`.
>   - **SDKs**:
>     - Update `BastionArgs` in `Bastion.cs`, `bastion.go`, `bastion.ts`, and `bastion.py` to include `architecture` field with default `x86_64`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Fpulumi-tailscale-bastion&utm_source=github&utm_medium=referral)<sup> for 5f9c91f5297c0573f42e6704c5831a95f97f6c91. You can [customize](https://app.ellipsis.dev/lbrlabs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->